### PR TITLE
Update pom.xml

### DIFF
--- a/iot/components/camel-tinkerforge/pom.xml
+++ b/iot/components/camel-tinkerforge/pom.xml
@@ -38,7 +38,12 @@
             <groupId>com.tinkerforge</groupId>
             <artifactId>tinkerforge</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.12</version>
+        </dependency>
+        
         <!-- testing -->
         <dependency>
             <groupId>org.apache.camel</groupId>


### PR DESCRIPTION
On my OSX 10.10.4 with $ java -version
java version "1.8.0_45"
Java(TM) SE Runtime Environment (build 1.8.0_45-b14)
Java HotSpot(TM) 64-Bit Server VM (build 25.45-b02, mixed mode)

I was getting this error after 'mvn install -DskipTests=true'

[ERROR] COMPILATION ERROR :
[ERROR] camel-labs/iot/components/camel-tinkerforge/src/main/java/com/github/camellabs/component/tinkerforge/TinkerforgeComponent.java:[23,17] package org.slf4j does not exist
[ERROR] camel-labs/iot/components/camel-tinkerforge/src/main/java/com/github/camellabs/component/tinkerforge/TinkerforgeComponent.java:[24,17] package org.slf4j does not exist
[ERROR] camel-labs/iot/components/camel-tinkerforge/src/main/java/com/github/camellabs/component/tinkerforge/TinkerforgeComponent.java:[43,40] cannot find symbol
  symbol:   class Logger
  location: class com.github.camellabs.component.tinkerforge.TinkerforgeComponent
[ERROR] camel-labs/iot/components/camel-tinkerforge/src/main/java/com/github/camellabs/component/tinkerforge/TinkerforgeComponent.java:[43,53] cannot find symbol
  symbol:   variable LoggerFactory
  location: class com.github.camellabs.component.tinkerforge.TinkerforgeComponent
...
[INFO] camel-labs-iot-components-tinkerforge .............. FAILURE [  0.198 s]

I added an org.slf4j dependency to the tinkerforge pom and that fixed it. There may be a better or more correct thing to do but this worked for me. Just passing this along in case it is helpful to anyone else.